### PR TITLE
remove cross-cite doi

### DIFF
--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -34,7 +34,6 @@ cross-cites:
       Data release: Predicting water temperature in the Delaware River Basin: U.S. Geological Survey data release
     pubdate: 2021
     form: publication
-    doi: 10.5066/P9GD8I7A
     link: https://doi.org/10.5066/P9GD8I7A
     
 process-date: !expr format(Sys.time(),'%Y%m%d')


### PR DESCRIPTION
This field doesn't seem to map to anything in the xml metadata - I think it is creating buggy behavior that makes the file format show up in related external resources. Can you manually delete both related external resources from the SB page? I think once you do that and rerun this pipeline without the doi field, it will work as expected.